### PR TITLE
Reduce hero image size on homepage

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -18,6 +18,14 @@ img {
     height: auto;
 }
 
+/* Limit the size of hero images on the home page */
+#about img,
+#education img {
+    max-width: 300px;
+    display: block;
+    margin: 0 auto 20px;
+}
+
 nav ul {
     list-style: none;
     padding: 0;


### PR DESCRIPTION
## Summary
- limit `#about` and `#education` images to 300px wide

## Testing
- `true`