### PR TITLE
Add research and education to CS page

### DIFF
--- a/computer-science/index.html
+++ b/computer-science/index.html
@@ -12,7 +12,47 @@
     </nav>
     <main>
         <h1>Computer Science</h1>
-        <p>Resources and articles about computing and software development.</p>
+        <section id="cs-research">
+            <h2>Computer Science Research and Projects</h2>
+            <ul>
+                <li>
+                    <strong>Autonomous Robotic Teams (2023)</strong>
+                    - Research Assistant at the University of Michigan-Flint, focusing on enhancing collaboration and autonomy in robotic teams.
+                </li>
+                <li>
+                    <a href="https://ieeexplore.ieee.org/abstract/document/10253851/">
+                    Autonomy and Fatigue in Human-Robot Teams (2023)</a>
+                    - Investigating the impact of autonomous behaviors on human-robot collaboration and team efficiency.
+                </li>
+                <li>
+                    <a href="https://www.researchgate.net/profile/Mark-Allison-2/publication/376953845_A_Layered_Architecture_for_Adaptive_Autonomy_in_Human-Robotic_Team_Interaction/">
+                    Layered Conceptual Framework for Shared Autonomy (2023)</a>
+                    - Developing architectures to improve adaptive autonomy within human-robot interactions.
+                </li>
+                <li>
+                    <a href="https://www.researchgate.net/profile/Mark-Allison-2/publication/376953800_A_Risk-Aware_Leaership_Structure_for_Heterogeneous_Robotic_Teams/">
+                    Risk-Aware Leadership Structure for Robotic Teams (2023)</a>
+                    - Proposing leadership models to manage risks effectively in diverse robotic teams.
+                </li>
+            </ul>
+        </section>
+
+        <section id="educational-work">
+            <h2>Educational Contributions in Computer Science</h2>
+            <ul>
+                <li>
+                    <strong>STEMNETICS Robotics Curriculum Development</strong>
+                    - Developed and implemented robotics and AI curricula for elementary education, training instructors and coordinating STEM events.
+                </li>
+            </ul>
+        </section>
+
+        <footer>
+            <h2>Connect</h2>
+            <p>Email: <a href="mailto:maxaeonparks@gmail.com">maxaeonparks@gmail.com</a></p>
+            <p>GitHub: <a href="https://github.com/maxaeon">github.com/maxaeon</a></p>
+            <p>Website: <a href="https://maparks.com">maparks.com</a></p>
+        </footer>
     </main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expand Computer Science page with research and educational contributions

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest`