### PR TITLE
Add accessible image pair to computer science page

### DIFF
--- a/computer-science/index.html
+++ b/computer-science/index.html
@@ -50,7 +50,16 @@
                     - Developed and implemented robotics and AI curricula for elementary education, training instructors and coordinating STEM events.
                 </li>
             </ul>
-            <img class="small-image" src="../assets/images/stem-day.png" alt="Presenting robotics activities during a STEM Day event">
+            <div class="image-row">
+                <figure>
+                    <img class="small-image" src="../assets/images/stem-day.png" alt="Max teaching families about robotics at a 2025 STEM Day event through STEMNETICS in Flint, Michigan">
+                    <figcaption>Max teaching families about robotics at a 2025 STEM Day event through STEMNETICS in Flint, Michigan</figcaption>
+                </figure>
+                <figure>
+                    <img class="small-image" src="../assets/images/coding.jpg" alt="Children learning to code with a 3D-printed game as part of the STEMNETICS robotics curriculum">
+                    <figcaption>Children learning to code with a 3D-printed game as part of the STEMNETICS robotics curriculum</figcaption>
+                </figure>
+            </div>
         </section>
 
         <footer></footer>

--- a/css/style.css
+++ b/css/style.css
@@ -38,6 +38,19 @@ main img {
     max-width: 150px;
 }
 
+/* Display two images side by side in the educational work section */
+.image-row {
+    display: flex;
+    gap: 20px;
+    justify-content: center;
+    align-items: flex-start;
+}
+
+.image-row img {
+    height: 150px;
+    width: auto;
+}
+
 /* Limit the size of hero images on the home page */
 #about img,
 #education img {


### PR DESCRIPTION
## Summary
- show STEM Day and coding photos side-by-side with new layout
- describe each photo with accessible captions
- style image pair for consistent height

## Testing
- `npm test` *(fails: could not find package.json)*