### PR TITLE
Reduce hero image width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -69,7 +69,7 @@ main img {
 /* Limit the size of hero images on the home page */
 #about img,
 #education img {
-    max-width: 300px;
+    max-width: 200px;
     display: block;
     margin: 0 auto 20px;
 }


### PR DESCRIPTION
## Summary
- adjust hero image styles so about and education images are less dominating

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683f012b49608322ab9d99ee780e351b